### PR TITLE
Reduce amount of copying/cloning within the transformation from `StreamerMessage` to `codec::Block`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -44,8 +44,7 @@ fn main() {
                 let mut stream = indexer.streamer();
                 actix::spawn(async move {
                     while let Some(streamer_message) = stream.recv().await {
-                        let block = codec::Block::from(&streamer_message);
-                        dm::on_block(&block);
+                        dm::on_block(&codec::Block::from(streamer_message));
                     }
                 });
             });


### PR DESCRIPTION
We were passing the top element as a reference as well as a bunch of other inner structures. This was causing unnecessary cloning of elements because we didn't had ownership of the top-level structure. We actually "own" the `StreamerMessage` which is dropped right after the transformation so it makes more sense to move it into the transformer and move as much value straight inside the proto instead of deeply cloning.

So, everything is now "moved" which means much less data need to be copied/created and mostly everything can be simply be "moved" in the right location. There was also useless usage of `clone` here and there which was doubly not required.
