### PR TITLE
bump near to v2.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v2.13.1-fh3.0
+
+* Bumped to [2.13.1](https://github.com/near/nearcore/releases/tag/2.13.1).
+
 ## v2.13.0-fh3.0
 
 * Bumped to [2.13.0](https://github.com/near/nearcore/releases/tag/2.13.0).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -912,7 +912,7 @@ dependencies = [
  "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "regex",
@@ -2867,7 +2867,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3100,15 +3100,6 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -3607,8 +3598,8 @@ dependencies = [
 
 [[package]]
 name = "near-async"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?rev=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "crossbeam-channel",
  "futures",
@@ -3627,8 +3618,8 @@ dependencies = [
 
 [[package]]
 name = "near-async-derive"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?rev=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3637,8 +3628,8 @@ dependencies = [
 
 [[package]]
 name = "near-cache"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?rev=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "lru 0.16.4",
  "parking_lot 0.12.5",
@@ -3646,8 +3637,8 @@ dependencies = [
 
 [[package]]
 name = "near-chain"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?rev=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3691,8 +3682,8 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?rev=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -3716,8 +3707,8 @@ dependencies = [
 
 [[package]]
 name = "near-chain-primitives"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?rev=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "near-crypto",
  "near-primitives",
@@ -3728,8 +3719,8 @@ dependencies = [
 
 [[package]]
 name = "near-chunks"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?rev=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "itertools 0.14.0",
  "lru 0.16.4",
@@ -3754,8 +3745,8 @@ dependencies = [
 
 [[package]]
 name = "near-chunks-primitives"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?rev=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "near-chain-primitives",
  "near-primitives",
@@ -3763,8 +3754,8 @@ dependencies = [
 
 [[package]]
 name = "near-client"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?rev=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3815,8 +3806,8 @@ dependencies = [
 
 [[package]]
 name = "near-client-primitives"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?rev=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "near-chain-primitives",
  "near-chunks-primitives",
@@ -3831,8 +3822,8 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?rev=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -3842,8 +3833,8 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?rev=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "aws-lc-rs",
  "blake2",
@@ -3869,8 +3860,8 @@ dependencies = [
 
 [[package]]
 name = "near-dyn-configs"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?rev=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "anyhow",
  "near-chain-configs",
@@ -3884,8 +3875,8 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-manager"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?rev=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "borsh",
  "itertools 0.14.0",
@@ -3909,8 +3900,8 @@ dependencies = [
 
 [[package]]
 name = "near-external-storage"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?rev=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "anyhow",
  "futures",
@@ -3926,7 +3917,7 @@ dependencies = [
 
 [[package]]
 name = "near-firehose-indexer"
-version = "2.13.0-fh3.0"
+version = "2.13.1-fh3.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -3958,8 +3949,8 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?rev=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "near-primitives-core",
 ]
@@ -3976,8 +3967,8 @@ dependencies = [
 
 [[package]]
 name = "near-indexer"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?rev=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "anyhow",
  "futures",
@@ -4003,8 +3994,8 @@ dependencies = [
 
 [[package]]
 name = "near-indexer-primitives"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?rev=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "near-primitives",
  "serde",
@@ -4012,8 +4003,8 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?rev=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "axum",
  "bs58 0.4.0",
@@ -4042,8 +4033,8 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client-internal"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?rev=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "futures",
  "near-jsonrpc-primitives",
@@ -4056,8 +4047,8 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?rev=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
@@ -4074,8 +4065,8 @@ dependencies = [
 
 [[package]]
 name = "near-mainnet-res"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?rev=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "near-account-id",
  "near-chain-configs",
@@ -4085,8 +4076,8 @@ dependencies = [
 
 [[package]]
 name = "near-network"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?rev=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4128,8 +4119,8 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?rev=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "base64 0.21.7",
  "clap",
@@ -4151,8 +4142,8 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?rev=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "borsh",
  "enum-map",
@@ -4169,8 +4160,8 @@ dependencies = [
 
 [[package]]
 name = "near-pool"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?rev=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "borsh",
  "near-crypto",
@@ -4181,8 +4172,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?rev=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -4224,8 +4215,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?rev=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -4247,8 +4238,8 @@ dependencies = [
 
 [[package]]
 name = "near-rosetta-rpc"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?rev=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "axum",
  "derive_more",
@@ -4278,13 +4269,13 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-core"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?rev=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 
 [[package]]
 name = "near-schema-checker-lib"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?rev=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "near-schema-checker-core",
  "near-schema-checker-macro",
@@ -4292,18 +4283,18 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-macro"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?rev=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 
 [[package]]
 name = "near-stdx"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?rev=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 
 [[package]]
 name = "near-store"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?rev=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
@@ -4353,8 +4344,8 @@ dependencies = [
 
 [[package]]
 name = "near-telemetry"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?rev=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "futures",
  "near-async",
@@ -4367,8 +4358,8 @@ dependencies = [
 
 [[package]]
 name = "near-time"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?rev=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "parking_lot 0.12.5",
  "serde",
@@ -4388,8 +4379,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?rev=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "enumset",
  "finite-wasm 0.5.1",
@@ -4404,8 +4395,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-singlepass"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?rev=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "dynasm",
  "dynasmrt",
@@ -4423,8 +4414,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-engine"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?rev=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "backtrace",
  "finite-wasm 0.5.1",
@@ -4442,8 +4433,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?rev=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "anyhow",
  "blst",
@@ -4492,8 +4483,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-types"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?rev=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "indexmap 2.14.0",
  "num-traits",
@@ -4503,8 +4494,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-vm"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?rev=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "backtrace",
  "cc",
@@ -4524,8 +4515,8 @@ dependencies = [
 
 [[package]]
 name = "near-wallet-contract"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?rev=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "anyhow",
  "near-primitives-core",
@@ -4534,8 +4525,8 @@ dependencies = [
 
 [[package]]
 name = "nearcore"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?rev=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4603,8 +4594,8 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?rev=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "ahash 0.8.12",
  "borsh",
@@ -5401,7 +5392,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -5573,7 +5564,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls 0.23.41",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5611,7 +5602,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["firehose-pb"]
 
 [package]
 name = "near-firehose-indexer"
-version = "2.13.0-fh3.0"
+version = "2.13.1-fh3.0"
 authors = ["StreamingFast Developers <dev@streamingfast.io>"]
 edition = "2024"
 
@@ -31,9 +31,9 @@ tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 
 # Additional dependencies for NEAR
-near-indexer = { git = "https://github.com/near/nearcore", rev = "2.13.0" }
-near-crypto = { git = "https://github.com/near/nearcore", rev = "2.13.0" }
-near-primitives = { git = "https://github.com/near/nearcore", rev = "2.13.0" }
+near-indexer = { git = "https://github.com/near/nearcore", rev = "2.13.1" }
+near-crypto = { git = "https://github.com/near/nearcore", rev = "2.13.1" }
+near-primitives = { git = "https://github.com/near/nearcore", rev = "2.13.1" }
 
 # StreamingFast needed dependencies
 base64 = "0.21"


### PR DESCRIPTION
## Summary

Bumps NEAR upstream dependency from `2.13.0` to [`2.13.1`](https://github.com/near/nearcore/releases/tag/2.13.1).

NEAR Firehose support is an external indexer plugin consuming the upstream `near/nearcore` git rev directly — no fork merge required, pure rev bump.

## Changes

- `Cargo.toml`: crate version `2.13.0-fh3.0` → `2.13.1-fh3.0`; `near-indexer`, `near-crypto`, `near-primitives` git rev `2.13.0` → `2.13.1` (`9d05464`)
- `Cargo.lock`: regenerated via `cargo update` for all `near-*` / `nearcore` / `node-runtime` packages
- `CHANGELOG.md`: new `## v2.13.1-fh3.0` section

## Testing

- `cargo test --no-run`: PASSED (compiles clean)
- `cargo test`: PASSED (0 tests in repo)