### PR TITLE
Bump NEAR to v2.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v2.13.2-fh3.0
+
+* Bumped to [2.13.2](https://github.com/near/nearcore/releases/tag/2.13.2).
+
 ## v2.13.1-fh3.0
 
 * Bumped to [2.13.1](https://github.com/near/nearcore/releases/tag/2.13.1).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3598,8 +3598,8 @@ dependencies = [
 
 [[package]]
 name = "near-async"
-version = "2.13.1"
-source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
+version = "2.13.2"
+source = "git+https://github.com/near/nearcore?rev=2.13.2#bb3f43910e801c7a58e5018f3f7ad33644ccd354"
 dependencies = [
  "crossbeam-channel",
  "futures",
@@ -3618,8 +3618,8 @@ dependencies = [
 
 [[package]]
 name = "near-async-derive"
-version = "2.13.1"
-source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
+version = "2.13.2"
+source = "git+https://github.com/near/nearcore?rev=2.13.2#bb3f43910e801c7a58e5018f3f7ad33644ccd354"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3628,8 +3628,8 @@ dependencies = [
 
 [[package]]
 name = "near-cache"
-version = "2.13.1"
-source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
+version = "2.13.2"
+source = "git+https://github.com/near/nearcore?rev=2.13.2#bb3f43910e801c7a58e5018f3f7ad33644ccd354"
 dependencies = [
  "lru 0.16.4",
  "parking_lot 0.12.5",
@@ -3637,8 +3637,8 @@ dependencies = [
 
 [[package]]
 name = "near-chain"
-version = "2.13.1"
-source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
+version = "2.13.2"
+source = "git+https://github.com/near/nearcore?rev=2.13.2#bb3f43910e801c7a58e5018f3f7ad33644ccd354"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3682,8 +3682,8 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "2.13.1"
-source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
+version = "2.13.2"
+source = "git+https://github.com/near/nearcore?rev=2.13.2#bb3f43910e801c7a58e5018f3f7ad33644ccd354"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -3707,8 +3707,8 @@ dependencies = [
 
 [[package]]
 name = "near-chain-primitives"
-version = "2.13.1"
-source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
+version = "2.13.2"
+source = "git+https://github.com/near/nearcore?rev=2.13.2#bb3f43910e801c7a58e5018f3f7ad33644ccd354"
 dependencies = [
  "near-crypto",
  "near-primitives",
@@ -3719,8 +3719,8 @@ dependencies = [
 
 [[package]]
 name = "near-chunks"
-version = "2.13.1"
-source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
+version = "2.13.2"
+source = "git+https://github.com/near/nearcore?rev=2.13.2#bb3f43910e801c7a58e5018f3f7ad33644ccd354"
 dependencies = [
  "itertools 0.14.0",
  "lru 0.16.4",
@@ -3745,8 +3745,8 @@ dependencies = [
 
 [[package]]
 name = "near-chunks-primitives"
-version = "2.13.1"
-source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
+version = "2.13.2"
+source = "git+https://github.com/near/nearcore?rev=2.13.2#bb3f43910e801c7a58e5018f3f7ad33644ccd354"
 dependencies = [
  "near-chain-primitives",
  "near-primitives",
@@ -3754,8 +3754,8 @@ dependencies = [
 
 [[package]]
 name = "near-client"
-version = "2.13.1"
-source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
+version = "2.13.2"
+source = "git+https://github.com/near/nearcore?rev=2.13.2#bb3f43910e801c7a58e5018f3f7ad33644ccd354"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3806,8 +3806,8 @@ dependencies = [
 
 [[package]]
 name = "near-client-primitives"
-version = "2.13.1"
-source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
+version = "2.13.2"
+source = "git+https://github.com/near/nearcore?rev=2.13.2#bb3f43910e801c7a58e5018f3f7ad33644ccd354"
 dependencies = [
  "near-chain-primitives",
  "near-chunks-primitives",
@@ -3822,8 +3822,8 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "2.13.1"
-source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
+version = "2.13.2"
+source = "git+https://github.com/near/nearcore?rev=2.13.2#bb3f43910e801c7a58e5018f3f7ad33644ccd354"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -3833,8 +3833,8 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "2.13.1"
-source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
+version = "2.13.2"
+source = "git+https://github.com/near/nearcore?rev=2.13.2#bb3f43910e801c7a58e5018f3f7ad33644ccd354"
 dependencies = [
  "aws-lc-rs",
  "blake2",
@@ -3860,8 +3860,8 @@ dependencies = [
 
 [[package]]
 name = "near-dyn-configs"
-version = "2.13.1"
-source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
+version = "2.13.2"
+source = "git+https://github.com/near/nearcore?rev=2.13.2#bb3f43910e801c7a58e5018f3f7ad33644ccd354"
 dependencies = [
  "anyhow",
  "near-chain-configs",
@@ -3875,8 +3875,8 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-manager"
-version = "2.13.1"
-source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
+version = "2.13.2"
+source = "git+https://github.com/near/nearcore?rev=2.13.2#bb3f43910e801c7a58e5018f3f7ad33644ccd354"
 dependencies = [
  "borsh",
  "itertools 0.14.0",
@@ -3900,8 +3900,8 @@ dependencies = [
 
 [[package]]
 name = "near-external-storage"
-version = "2.13.1"
-source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
+version = "2.13.2"
+source = "git+https://github.com/near/nearcore?rev=2.13.2#bb3f43910e801c7a58e5018f3f7ad33644ccd354"
 dependencies = [
  "anyhow",
  "futures",
@@ -3917,7 +3917,7 @@ dependencies = [
 
 [[package]]
 name = "near-firehose-indexer"
-version = "2.13.1-fh3.0"
+version = "2.13.2-fh3.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -3949,8 +3949,8 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "2.13.1"
-source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
+version = "2.13.2"
+source = "git+https://github.com/near/nearcore?rev=2.13.2#bb3f43910e801c7a58e5018f3f7ad33644ccd354"
 dependencies = [
  "near-primitives-core",
 ]
@@ -3967,8 +3967,8 @@ dependencies = [
 
 [[package]]
 name = "near-indexer"
-version = "2.13.1"
-source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
+version = "2.13.2"
+source = "git+https://github.com/near/nearcore?rev=2.13.2#bb3f43910e801c7a58e5018f3f7ad33644ccd354"
 dependencies = [
  "anyhow",
  "futures",
@@ -3994,8 +3994,8 @@ dependencies = [
 
 [[package]]
 name = "near-indexer-primitives"
-version = "2.13.1"
-source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
+version = "2.13.2"
+source = "git+https://github.com/near/nearcore?rev=2.13.2#bb3f43910e801c7a58e5018f3f7ad33644ccd354"
 dependencies = [
  "near-primitives",
  "serde",
@@ -4003,8 +4003,8 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc"
-version = "2.13.1"
-source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
+version = "2.13.2"
+source = "git+https://github.com/near/nearcore?rev=2.13.2#bb3f43910e801c7a58e5018f3f7ad33644ccd354"
 dependencies = [
  "axum",
  "bs58 0.4.0",
@@ -4033,8 +4033,8 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client-internal"
-version = "2.13.1"
-source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
+version = "2.13.2"
+source = "git+https://github.com/near/nearcore?rev=2.13.2#bb3f43910e801c7a58e5018f3f7ad33644ccd354"
 dependencies = [
  "futures",
  "near-jsonrpc-primitives",
@@ -4047,8 +4047,8 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "2.13.1"
-source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
+version = "2.13.2"
+source = "git+https://github.com/near/nearcore?rev=2.13.2#bb3f43910e801c7a58e5018f3f7ad33644ccd354"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
@@ -4065,8 +4065,8 @@ dependencies = [
 
 [[package]]
 name = "near-mainnet-res"
-version = "2.13.1"
-source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
+version = "2.13.2"
+source = "git+https://github.com/near/nearcore?rev=2.13.2#bb3f43910e801c7a58e5018f3f7ad33644ccd354"
 dependencies = [
  "near-account-id",
  "near-chain-configs",
@@ -4076,8 +4076,8 @@ dependencies = [
 
 [[package]]
 name = "near-network"
-version = "2.13.1"
-source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
+version = "2.13.2"
+source = "git+https://github.com/near/nearcore?rev=2.13.2#bb3f43910e801c7a58e5018f3f7ad33644ccd354"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4119,8 +4119,8 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "2.13.1"
-source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
+version = "2.13.2"
+source = "git+https://github.com/near/nearcore?rev=2.13.2#bb3f43910e801c7a58e5018f3f7ad33644ccd354"
 dependencies = [
  "base64 0.21.7",
  "clap",
@@ -4142,8 +4142,8 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "2.13.1"
-source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
+version = "2.13.2"
+source = "git+https://github.com/near/nearcore?rev=2.13.2#bb3f43910e801c7a58e5018f3f7ad33644ccd354"
 dependencies = [
  "borsh",
  "enum-map",
@@ -4160,8 +4160,8 @@ dependencies = [
 
 [[package]]
 name = "near-pool"
-version = "2.13.1"
-source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
+version = "2.13.2"
+source = "git+https://github.com/near/nearcore?rev=2.13.2#bb3f43910e801c7a58e5018f3f7ad33644ccd354"
 dependencies = [
  "borsh",
  "near-crypto",
@@ -4172,8 +4172,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "2.13.1"
-source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
+version = "2.13.2"
+source = "git+https://github.com/near/nearcore?rev=2.13.2#bb3f43910e801c7a58e5018f3f7ad33644ccd354"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -4215,8 +4215,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "2.13.1"
-source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
+version = "2.13.2"
+source = "git+https://github.com/near/nearcore?rev=2.13.2#bb3f43910e801c7a58e5018f3f7ad33644ccd354"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -4238,8 +4238,8 @@ dependencies = [
 
 [[package]]
 name = "near-rosetta-rpc"
-version = "2.13.1"
-source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
+version = "2.13.2"
+source = "git+https://github.com/near/nearcore?rev=2.13.2#bb3f43910e801c7a58e5018f3f7ad33644ccd354"
 dependencies = [
  "axum",
  "derive_more",
@@ -4269,13 +4269,13 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-core"
-version = "2.13.1"
-source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
+version = "2.13.2"
+source = "git+https://github.com/near/nearcore?rev=2.13.2#bb3f43910e801c7a58e5018f3f7ad33644ccd354"
 
 [[package]]
 name = "near-schema-checker-lib"
-version = "2.13.1"
-source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
+version = "2.13.2"
+source = "git+https://github.com/near/nearcore?rev=2.13.2#bb3f43910e801c7a58e5018f3f7ad33644ccd354"
 dependencies = [
  "near-schema-checker-core",
  "near-schema-checker-macro",
@@ -4283,18 +4283,18 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-macro"
-version = "2.13.1"
-source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
+version = "2.13.2"
+source = "git+https://github.com/near/nearcore?rev=2.13.2#bb3f43910e801c7a58e5018f3f7ad33644ccd354"
 
 [[package]]
 name = "near-stdx"
-version = "2.13.1"
-source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
+version = "2.13.2"
+source = "git+https://github.com/near/nearcore?rev=2.13.2#bb3f43910e801c7a58e5018f3f7ad33644ccd354"
 
 [[package]]
 name = "near-store"
-version = "2.13.1"
-source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
+version = "2.13.2"
+source = "git+https://github.com/near/nearcore?rev=2.13.2#bb3f43910e801c7a58e5018f3f7ad33644ccd354"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
@@ -4344,8 +4344,8 @@ dependencies = [
 
 [[package]]
 name = "near-telemetry"
-version = "2.13.1"
-source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
+version = "2.13.2"
+source = "git+https://github.com/near/nearcore?rev=2.13.2#bb3f43910e801c7a58e5018f3f7ad33644ccd354"
 dependencies = [
  "futures",
  "near-async",
@@ -4358,8 +4358,8 @@ dependencies = [
 
 [[package]]
 name = "near-time"
-version = "2.13.1"
-source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
+version = "2.13.2"
+source = "git+https://github.com/near/nearcore?rev=2.13.2#bb3f43910e801c7a58e5018f3f7ad33644ccd354"
 dependencies = [
  "parking_lot 0.12.5",
  "serde",
@@ -4379,8 +4379,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler"
-version = "2.13.1"
-source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
+version = "2.13.2"
+source = "git+https://github.com/near/nearcore?rev=2.13.2#bb3f43910e801c7a58e5018f3f7ad33644ccd354"
 dependencies = [
  "enumset",
  "finite-wasm 0.5.1",
@@ -4395,8 +4395,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-singlepass"
-version = "2.13.1"
-source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
+version = "2.13.2"
+source = "git+https://github.com/near/nearcore?rev=2.13.2#bb3f43910e801c7a58e5018f3f7ad33644ccd354"
 dependencies = [
  "dynasm",
  "dynasmrt",
@@ -4414,8 +4414,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-engine"
-version = "2.13.1"
-source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
+version = "2.13.2"
+source = "git+https://github.com/near/nearcore?rev=2.13.2#bb3f43910e801c7a58e5018f3f7ad33644ccd354"
 dependencies = [
  "backtrace",
  "finite-wasm 0.5.1",
@@ -4433,8 +4433,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "2.13.1"
-source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
+version = "2.13.2"
+source = "git+https://github.com/near/nearcore?rev=2.13.2#bb3f43910e801c7a58e5018f3f7ad33644ccd354"
 dependencies = [
  "anyhow",
  "blst",
@@ -4483,8 +4483,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-types"
-version = "2.13.1"
-source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
+version = "2.13.2"
+source = "git+https://github.com/near/nearcore?rev=2.13.2#bb3f43910e801c7a58e5018f3f7ad33644ccd354"
 dependencies = [
  "indexmap 2.14.0",
  "num-traits",
@@ -4494,8 +4494,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-vm"
-version = "2.13.1"
-source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
+version = "2.13.2"
+source = "git+https://github.com/near/nearcore?rev=2.13.2#bb3f43910e801c7a58e5018f3f7ad33644ccd354"
 dependencies = [
  "backtrace",
  "cc",
@@ -4515,8 +4515,8 @@ dependencies = [
 
 [[package]]
 name = "near-wallet-contract"
-version = "2.13.1"
-source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
+version = "2.13.2"
+source = "git+https://github.com/near/nearcore?rev=2.13.2#bb3f43910e801c7a58e5018f3f7ad33644ccd354"
 dependencies = [
  "anyhow",
  "near-primitives-core",
@@ -4525,8 +4525,8 @@ dependencies = [
 
 [[package]]
 name = "nearcore"
-version = "2.13.1"
-source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
+version = "2.13.2"
+source = "git+https://github.com/near/nearcore?rev=2.13.2#bb3f43910e801c7a58e5018f3f7ad33644ccd354"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4594,8 +4594,8 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "2.13.1"
-source = "git+https://github.com/near/nearcore?rev=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
+version = "2.13.2"
+source = "git+https://github.com/near/nearcore?rev=2.13.2#bb3f43910e801c7a58e5018f3f7ad33644ccd354"
 dependencies = [
  "ahash 0.8.12",
  "borsh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["firehose-pb"]
 
 [package]
 name = "near-firehose-indexer"
-version = "2.13.1-fh3.0"
+version = "2.13.2-fh3.0"
 authors = ["StreamingFast Developers <dev@streamingfast.io>"]
 edition = "2024"
 
@@ -31,9 +31,9 @@ tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 
 # Additional dependencies for NEAR
-near-indexer = { git = "https://github.com/near/nearcore", rev = "2.13.1" }
-near-crypto = { git = "https://github.com/near/nearcore", rev = "2.13.1" }
-near-primitives = { git = "https://github.com/near/nearcore", rev = "2.13.1" }
+near-indexer = { git = "https://github.com/near/nearcore", rev = "2.13.2" }
+near-crypto = { git = "https://github.com/near/nearcore", rev = "2.13.2" }
+near-primitives = { git = "https://github.com/near/nearcore", rev = "2.13.2" }
 
 # StreamingFast needed dependencies
 base64 = "0.21"


### PR DESCRIPTION
Bumps `nearcore` dependencies (`near-indexer`, `near-crypto`, `near-primitives`) from `2.13.1` to [`2.13.2`](https://github.com/near/nearcore/releases/tag/2.13.2) and releases as `v2.13.2-fh3.0`.

### Upstream review

The [2.13.1...2.13.2 diff](https://github.com/near/nearcore/compare/2.13.1...2.13.2) (18 commits) touches only networking, chunk management, spice and runtime internals. No changes to `core/primitives` views, actions, access keys or error enums, so **no codec changes were required** — `src/codec/mod.rs` contains no `unimplemented!` paths.

`rust-toolchain.toml` is unchanged upstream (still `1.93`).

### Validation

- `cargo test` — passes (compiles cleanly; suite has no tests)
- `make release` — passes (fat LTO, `-D warnings`)